### PR TITLE
bugfix_#102

### DIFF
--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -111,7 +111,7 @@ var current_user = "007";
 var HTMLforPost = "uninitialized";
 var HTMLforComment = "uninitialized";
 var defaultPostSize = 0;
-var deviceType = "mobile";
+var deviceType = "desktop";
 var defaultLimit = 15;
 var openMenu = "none";
 
@@ -382,8 +382,8 @@ function resizePosts() {
         
         if(defaultPostSize == 0) {
             defaultPostSize = parseInt($("#postContainer_" + question.getId()).css('height'));
-            if(defaultPostSize < 275)
-                deviceType = "desktop";
+            if(defaultPostSize >= 275)
+                deviceType = "mobile";
         }
         
         var str = $("#textContainer_" + question.getId()).css('height');


### PR DESCRIPTION
Fixed.

The program automatically assumed that the user was on mobile before checking later in resizePosts().

Also, on mobile only, the filter bar will stick to the top of the page after you scroll a certain amount.

This meant that if you scrolled that certain amount before the program checked if you were on desktop, it would change the position type of the filter bar from relative to fixed, and stay fixed at the top of the page on desktop. 

This was fixed by changing the default assumption of device type from mobile to desktop, and later in the program, instead of checking if the user is on desktop, it checks if they are on mobile and sets the type then.
